### PR TITLE
不要な条件を削除

### DIFF
--- a/Packages/net.koyashiro.udontest/Runtime/Assert.cs
+++ b/Packages/net.koyashiro.udontest/Runtime/Assert.cs
@@ -100,8 +100,7 @@ namespace Koyashiro.UdonTest
                 return false;
             }
 
-            if (objAType.Name.EndsWith("[]")
-             || objAType == typeof(Array))
+            if (objAType.Name.EndsWith("[]"))
             {
                 return Equals((Array)objA, (Array)objB);
             }
@@ -138,8 +137,7 @@ namespace Koyashiro.UdonTest
 
             var objType = obj.GetType();
 
-            if (objType.Name.EndsWith("[]")
-             || objType == typeof(Array))
+            if (objType.Name.EndsWith("[]"))
             {
                 return ToDebugString((Array)obj);
             }

--- a/Packages/net.koyashiro.udontest/Runtime/Assert.cs
+++ b/Packages/net.koyashiro.udontest/Runtime/Assert.cs
@@ -73,8 +73,8 @@ namespace Koyashiro.UdonTest
             var expectedType = expected == null ? "null" : expected.GetType().ToString();
             var actualType = actual == null ? "null" : actual.GetType().ToString();
             var message = string.Concat(
-                $"[<color={COLOR_TAG}>UdonTest</color>] Test <color={COLOR_FAILED}>FAILED!</color>\n" +
-                $"expected: <color={COLOR_EXPECTED}>{ToDebugString(expected)}</color> ({expectedType})\t" +
+                $"[<color={COLOR_TAG}>UdonTest</color>] Test <color={COLOR_FAILED}>FAILED!</color>\n",
+                $"expected: <color={COLOR_EXPECTED}>{ToDebugString(expected)}</color> ({expectedType})\t",
                 $"actual: <color={COLOR_ACTUAL}>{ToDebugString(actual)}</color> ({actualType})");
             Debug.LogError(message, context);
         }

--- a/Packages/net.koyashiro.udontest/Runtime/Assert.cs
+++ b/Packages/net.koyashiro.udontest/Runtime/Assert.cs
@@ -86,10 +86,9 @@ namespace Koyashiro.UdonTest
             {
                 return objB == null;
             }
-
-            if (objB == null)
+            else if (objB == null)
             {
-                return objA == null;
+                return false;
             }
 
             var objAType = objA.GetType();


### PR DESCRIPTION
・不要な条件を削除します。
`Array.CreateInstance(typeof(int), 0).GetType().Name`は`Int32[]`となることを確かめたので、`objType == typeof(Array)`に到達することは有りませんでした。